### PR TITLE
Start time entry with a time and list entries without projects

### DIFF
--- a/toggl.py
+++ b/toggl.py
@@ -74,7 +74,6 @@ def add_time_entry(args):
     headers = {'content-type': 'application/json'}
     r = requests.post("%s/time_entries" % TOGGL_URL, auth=AUTH,
         data=json.dumps(data), headers=headers)
-    print r.response
     r.raise_for_status() # raise exception on error
     
     return 0

--- a/toggl.py
+++ b/toggl.py
@@ -74,6 +74,7 @@ def add_time_entry(args):
     headers = {'content-type': 'application/json'}
     r = requests.post("%s/time_entries" % TOGGL_URL, auth=AUTH,
         data=json.dumps(data), headers=headers)
+    print r.response
     r.raise_for_status() # raise exception on error
     
     return 0
@@ -296,7 +297,7 @@ def list_time_entries():
 			days[start_time] = []
 		days[start_time].append(entry)
 		# Lookup the project if it exists
-        	project_name = "No project"
+        	entry['project_name'] = "No project"
     		if 'pid' in entry:
 	   	    for project in projects:
 	       	        if entry['pid'] == project['id']:

--- a/toggl.py
+++ b/toggl.py
@@ -3,7 +3,7 @@
 toggl.py
 
 Created by Robert Adams on 2012-04-19.
-Last modified: 2014-09-14
+Last modified: 2014-10-13
 Copyright (c) 2012 D. Robert Adams. All rights reserved.
 Modified for toggl API v8 by Beau Raines
 """


### PR DESCRIPTION
I switched the start_time_entries function to the time_entries endpoint, rather than time_entries/start.  the start endpoint only uses the current time and the time_entries one allows you to specify start (and finish) times.

I also found an error where the print_time_entries would fail if the time entry didn't have a project. I made sure to _properly_ set a a default "no project" description. I think I tried to do this before, but I didn't do  it right.
