### PR TITLE
fix time-entry start path

### DIFF
--- a/toggl.py
+++ b/toggl.py
@@ -586,7 +586,7 @@ class TimeEntry(object):
 
         self.validate()
 
-        toggl("%s/time_entries" % TOGGL_URL, "post", self.json())
+        toggl("%s/time_entries/start" % TOGGL_URL, "post", self.json())
         Logger.debug('Started time entry: %s' % self.json())
 
     def stop(self, stop_time=None):


### PR DESCRIPTION
According to the Toggl API, in order to really start a time entry we
must use the 'start' command. A time-entry created without asserting the
'start' command is not flagged as "started" even if we can see it
running on the web interface.

https://github.com/toggl/toggl_api_docs/blob/master/chapters/time_entries.md

Signed-off-by: Federico Vaga federico.vaga@gmail.com
