### PR TITLE
TimeEntry.start(): use start endpoint when start_time is now

### DIFF
--- a/toggl.py
+++ b/toggl.py
@@ -579,14 +579,18 @@ class TimeEntry(object):
         """
         if self.has('start'):
             start_time = DateAndTime().parse_iso_str(self.get('start'))
+            self.set('duration', 0-DateAndTime().duration_since_epoch(start_time))
+
+            self.validate()
+
+            toggl("%s/time_entries" % TOGGL_URL, "post", self.json())
         else:
-            start_time = DateAndTime().now()
-            self.data['start'] = start_time.isoformat()
-        self.set('duration', 0-DateAndTime().duration_since_epoch(start_time))
+            # 'start' is ignored by 'time_entries/start' endpoint. We define it
+            # to keep consinstency with toggl server
+            self.data['start'] = DateAndTime().now().isoformat()
 
-        self.validate()
+            toggl("%s/time_entries/start" % TOGGL_URL, "post", self.json())
 
-        toggl("%s/time_entries" % TOGGL_URL, "post", self.json())
         Logger.debug('Started time entry: %s' % self.json())
 
     def stop(self, stop_time=None):


### PR DESCRIPTION
It happens, probably due to localization, that the current time is not
communicated properly.

In order start a time-entry with the current time we can use the
time_entries/start endpoint. The advantage is that we do not have
to handle start time which is managed by toggl web service.

https://github.com/toggl/toggl_api_docs/blob/master/chapters/time_entries.md

Signed-off-by: Federico Vaga federico.vaga@gmail.com
