### PR TITLE
added DURATION option to START/DURATION|STOP in add command

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,9 @@ Usage
     
     Actions:
       add DESCR [:WORKSPACE] [@PROJECT] START_DATETIME ('d'DURATION | END_DATETIME)
-            creates a completed time entry
+        creates a completed time entry
+      add DESCR [:WORKSPACE] [@PROJECT] 'd'DURATION
+        creates a completed time entry, with start time DURATION ago
       clients
             lists all clients
       continue DESCR

--- a/toggl.py
+++ b/toggl.py
@@ -1013,6 +1013,7 @@ class CLI(object):
         self.parser = optparse.OptionParser(usage="Usage: %prog [OPTIONS] [ACTION]", \
             epilog="\nActions:\n"
             "  add DESCR [:WORKSPACE] [@PROJECT] START_DATETIME ('d'DURATION | END_DATETIME)\n\tcreates a completed time entry\n"
+            "  add DESCR [:WORKSPACE] [@PROJECT] 'd'DURATION\n\tcreates a completed time entry, with start time DURATION ago\n"
             "  clients\n\tlists all clients\n"
             "  continue DESCR\n\trestarts the given entry\n"
             "  ls [starttime endtime]\n\tlist (recent) time entries\n"
@@ -1056,6 +1057,7 @@ class CLI(object):
         Creates a completed time entry.
         args should be: DESCR [:WORKSPACE] [@PROJECT] START_DATE_TIME
             'd'DURATION | STOP_DATE_TIME
+        or: DESCR [:WORKSPACE] [@PROJECT] 'd'DURATION
         """
         # Process the args.
         description = self._get_str_arg(args)
@@ -1073,13 +1075,18 @@ class CLI(object):
             if project == None:
                 raise RuntimeError("Project '%s' not found." % project_name)
 
-        start_time = self._get_datetime_arg(args, optional=False)
-        duration = self._get_duration_arg(args, optional=True)
-        if duration is None:
-            stop_time = self._get_datetime_arg(args, optional=False)
-            duration = (stop_time - start_time).total_seconds()
-        else:
-            stop_time = None
+    	duration = self._get_duration_arg(args, optional=True)
+    	if duration is not None:
+    		start_time = DateAndTime().now() - datetime.timedelta(seconds=duration)
+    		stop_time = None
+    	else:
+	        start_time = self._get_datetime_arg(args, optional=False)
+	        duration = self._get_duration_arg(args, optional=True)
+	        if duration is None:
+	            stop_time = self._get_datetime_arg(args, optional=False)
+	            duration = (stop_time - start_time).total_seconds()
+	        else:
+	            stop_time = None
 
         # Create a time entry.
         entry = TimeEntry(


### PR DESCRIPTION
For the scenario where you have completed some work, did not start the timer, but are aware of the duration, you can now add a completed entry for a given duration.  The entry will start DURATION ago, and finish now.

Format: `add DESCR [:WORKSPACE] [@PROJECT] 'd'DURATION`

Example: `add "my description" "@my project" d00:35:00"` - will add a completed entry that started 35 minutes ago, and finishes now.

Tested other add parameters (START/STOP, START/DURATION), they are not affected and still work with this update.
