### PR TITLE
Add DATETIME | 'd'DURATION to continue

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,10 @@ Usage
             creates a completed time entry, with start time DURATION ago
       clients
             lists all clients
-      continue DESCR
-            restarts the given entry
+      continue [from DATETIME | 'd'DURATION]
+            restarts the last entry
+      continue DESCR [from DATETIME | 'd'DURATION]
+            restarts the last entry matching DESCR
       ls [starttime endtime]
             list (recent) time entries
       ical [starttime endtime]

--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ Usage
     
     Actions:
       add DESCR [:WORKSPACE] [@PROJECT] START_DATETIME ('d'DURATION | END_DATETIME)
-        creates a completed time entry
+            creates a completed time entry
       add DESCR [:WORKSPACE] [@PROJECT] 'd'DURATION
-        creates a completed time entry, with start time DURATION ago
+            creates a completed time entry, with start time DURATION ago
       clients
             lists all clients
       continue DESCR


### PR DESCRIPTION
For when you've started work x minutes ago, or at a certain time, but have not yet started/continued the timer, you can now continue a prior item and (optionally) specify when you started on it;

```
continue [from DATETIME | 'd'DURATION]
    restarts the last entry
continue DESCR [from DATETIME | 'd'DURATION]
    restarts the last entry matching DESCR
```

Prior usage of `continue` still remains.  When using `from DATETIME`, `now-DATETIME` is added to the entry's duration when `continue`ing an entry that exists today.
