### PR TITLE
Add missing dependency - dateutils

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Requirements
 * iso8601 module
 * pytz module
 * requests
-* dateutil
+* dateutils
 
 Configuration
 -------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 iso8601
 pytz
 requests
+dateutils


### PR DESCRIPTION
## Issue

After cloning and installation of packages from requirements.txt, command `toggl-cli add DESCRIPTION` raises:

```
Traceback (most recent call last):
  File "toggl.py", line 17, in <module>
    import dateutil.parser
ImportError: No module named dateutil.parser
```
## What fixes it

Not sure what package you had in mind, but installing `dateutils` (notice last 's') fixes this issue. So I mentioned it in requirements.txt and update README. Correct me if my solution is wrong, but I can not find name 'dateutil' in pypi.python.org, only 'dateutils' (notice last 's').
