### PR TITLE
Fix missing dependency of python-dateutil

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Requirements
 * iso8601 module
 * pytz module
 * requests
-* dateutil
+* python-dateutil
 
 Configuration
 -------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 iso8601
 pytz
 requests
+python-dateutil


### PR DESCRIPTION
Previously opened https://github.com/drobertadams/toggl-cli/pull/58 but it was rejected because of unknown depdendency.

This one fixes missing package issue. Without that you were unable to use project. Here is how to reproduce it:

```
$ virtualenv .virtualenv
$ source .virtualenv/bin/activate
$ pip install -r requirements.txt
$ python toggl.py add TEST d25:00
Traceback (most recent call last):
  File "toggl.py", line 17, in <module>
    import dateutil.parser
 ImportError: No module named dateutil.parser
```

What fixes it:

```
$ pip install python-dateutil
$ python toggl.py add TEST d25:00
TEST added
```
