### PR TITLE
Issue with TimeEntry with utf-8 character

### DIFF
--- a/toggl.py
+++ b/toggl.py
@@ -756,7 +756,7 @@ class TimeEntry(object):
         if VERBOSE:
             s += " [%s]" % self.data['id']
 
-        return s
+        return s.encode("utf-8")
 
     def validate(self, exclude=[]):
         """


### PR DESCRIPTION
Having a TimeEntry with description containing the UTF-8 characters do returns:

```
Traceback (most recent call last):
  File "~/.toggl/toggl.py", line 1266, in <module>
    CLI().act()
  File "~/.toggl/toggl.py", line 1040, in act
    Logger.info(TimeEntryList())
  File "~/.toggl/toggl.py", line 294, in info
    print("%s%s" % (msg, end)),
  File "~/.toggl/toggl.py", line 881, in __str__
    s += str(entry) + "\n"
UnicodeEncodeError: 'ascii' codec can't encode character u'\u0107' in position 38: ordinal not in range(128)
```

Example description:
"Member - nie jestem w stanie otworzyć konwersacji innych niż..."

I'm not a python expert, but this fix did resolve the issue for me.