### PR TITLE
Add ability to specify project by ID with # character (ex. #123456)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,9 @@ Usage
       -d, --debug    print debugging output
     
     Actions:
-      add DESCR [:WORKSPACE] [@PROJECT] START_DATETIME ('d'DURATION | END_DATETIME)
+      add DESCR [:WORKSPACE] [@PROJECT | #PROJECT_ID] START_DATETIME ('d'DURATION | END_DATETIME)
             creates a completed time entry
-      add DESCR [:WORKSPACE] [@PROJECT] 'd'DURATION
+      add DESCR [:WORKSPACE] [@PROJECT | #PROJECT_ID] 'd'DURATION
             creates a completed time entry, with start time DURATION ago
       clients
             lists all clients
@@ -91,7 +91,7 @@ Usage
             lists all projects
       rm ID
             delete a time entry by id
-      start DESCR [:WORKSPACE] [@PROJECT] ['d'DURATION | DATETIME]
+      start DESCR [:WORKSPACE] [@PROJECT | #PROJECT_ID] ['d'DURATION | DATETIME]
             starts a new entry
       stop [DATETIME]
             stops the current entry


### PR DESCRIPTION
Add the ability to specify a project by ID with a `#` character (ex `#12345`). This is useful in the case where two or more distinct projects share the same name.

Print the IDs when using the `projects` sub-command.