### PR TITLE
Simple cache

### DIFF
--- a/toggl/api/base.py
+++ b/toggl/api/base.py
@@ -462,6 +462,8 @@ class TogglEntity(metaclass=TogglEntityMeta):
         self.validate()
 
         if self.id is not None:  # Update
+            if config.cache_requests:
+                utils.toggl.cache_clear()
             utils.toggl('/{}/{}'.format(self.get_url(), self.id), 'put', self.json(update=True), config=config)
             self.__change_dict__ = {}  # Reset tracking changes
         else:  # Create

--- a/toggl/api/base.py
+++ b/toggl/api/base.py
@@ -461,9 +461,10 @@ class TogglEntity(metaclass=TogglEntityMeta):
 
         self.validate()
 
+        if config.cache_requests:
+            utils.toggl.cache_clear()
+
         if self.id is not None:  # Update
-            if config.cache_requests:
-                utils.toggl.cache_clear()
             utils.toggl('/{}/{}'.format(self.get_url(), self.id), 'put', self.json(update=True), config=config)
             self.__change_dict__ = {}  # Reset tracking changes
         else:  # Create
@@ -485,7 +486,12 @@ class TogglEntity(metaclass=TogglEntityMeta):
         if not self.id:
             raise exceptions.TogglException('This instance has not been saved yet!')
 
-        utils.toggl('/{}/{}'.format(self.get_url(), self.id), 'delete', config=config or self._config)
+        config = config or self._config
+
+        if config.cache_requests:
+            utils.toggl.cache_clear()
+
+        utils.toggl('/{}/{}'.format(self.get_url(), self.id), 'delete', config=config)
         self.id = None  # Invalidate the object, so when save() is called after delete a new object is created
 
     def json(self, update=False):  # type: (bool) -> str

--- a/toggl/api/models.py
+++ b/toggl/api/models.py
@@ -86,6 +86,10 @@ class Workspace(base.TogglEntity):
                 raise exceptions.TogglValidationException('Supplied email \'{}\' is not valid email!'.format(email))
 
         emails_json = json.dumps({'emails': emails})
+
+        if self._config.cache_requests:
+            utils.toggl.cache_clear()
+
         data = utils.toggl("/workspaces/{}/invite".format(self.id), "post", emails_json, config=self._config)
 
         if 'notifications' in data and data['notifications']:
@@ -333,6 +337,10 @@ class User(WorkspacedEntity):
             'timezone': timezone,
             'created_with': created_with
         }})
+
+        if config.cache_requests:
+            utils.toggl.cache_clear()
+
         data = utils.toggl("/signups", "post", user_json, config=config)
         return cls.deserialize(config=config, **data['data'])
 

--- a/toggl/utils/config.py
+++ b/toggl/utils/config.py
@@ -261,6 +261,11 @@ class Config(EnvConfigMixin, IniConfigMixin, metaclass=ConfigMeta):
     """
     tz = None
 
+    """
+    Size of the HTTP API cache. Ignored if cache is disabled.
+    """
+    cache_size = 256
+
     ENV_MAPPING = {
         'api_token': EnvEntry('TOGGL_API_TOKEN', str),
         'user_name': EnvEntry('TOGGL_USERNAME', str),
@@ -282,6 +287,7 @@ class Config(EnvConfigMixin, IniConfigMixin, metaclass=ConfigMeta):
         'time_format': IniEntry('options', str),
         'default_wid': IniEntry('options', int),
         'retries': IniEntry('options', int),
+        'cache_size': IniEntry('options', int),
     }
 
     def __init__(self, config_path=sentinel, read_env=True, **kwargs):  # type: (str, bool, **typing.Any) -> None

--- a/toggl/utils/config.py
+++ b/toggl/utils/config.py
@@ -266,6 +266,11 @@ class Config(EnvConfigMixin, IniConfigMixin, metaclass=ConfigMeta):
     """
     cache_size = 256
 
+    """
+    Turns on/off the caching of HTTP API calls.
+    """
+    cache_requests = True
+
     ENV_MAPPING = {
         'api_token': EnvEntry('TOGGL_API_TOKEN', str),
         'user_name': EnvEntry('TOGGL_USERNAME', str),
@@ -288,6 +293,7 @@ class Config(EnvConfigMixin, IniConfigMixin, metaclass=ConfigMeta):
         'default_wid': IniEntry('options', int),
         'retries': IniEntry('options', int),
         'cache_size': IniEntry('options', int),
+        'cache_requests': IniEntry('options', bool),
     }
 
     def __init__(self, config_path=sentinel, read_env=True, **kwargs):  # type: (str, bool, **typing.Any) -> None

--- a/toggl/utils/others.py
+++ b/toggl/utils/others.py
@@ -145,10 +145,11 @@ def _toggl_request(url, method, data, headers, auth):
     return response
 
 
-@lru_cache(maxsize=Config.cache_size)
 def toggl(url, method, data=None, headers=None, config=None, address=None):
     """
     Makes an HTTP request to toggl.com. Returns the parsed JSON as dict.
+    Results are cached in an LRU-cache unless disabled through the configuration.
+    Cache can be cleared by calling `api.others.toggl.cache_clear()'
     """
     from ..toggl import TOGGL_URL
 
@@ -177,3 +178,8 @@ def toggl(url, method, data=None, headers=None, config=None, address=None):
 
     # If retries failed then 'e' contains the last Exception/Error, lets re-raise it!
     raise exception
+
+
+if Config.cache_requests:
+    # Manual conditional wrapping of the toggl function
+    toggl = lru_cache(maxsize=Config.cache_size)(toggl)

--- a/toggl/utils/others.py
+++ b/toggl/utils/others.py
@@ -149,7 +149,8 @@ def toggl(url, method, data=None, headers=None, config=None, address=None):
     """
     Makes an HTTP request to toggl.com. Returns the parsed JSON as dict.
     Results are cached in an LRU-cache unless disabled through the configuration.
-    Cache can be cleared by calling `api.others.toggl.cache_clear()'
+    Cache can be cleared by calling `api.others.toggl.cache_clear()`.
+    The cache will be cleared automatically on any 'put', 'post' or 'delete'.
     """
     from ..toggl import TOGGL_URL
 

--- a/toggl/utils/others.py
+++ b/toggl/utils/others.py
@@ -1,5 +1,6 @@
 import logging
 import json
+from functools import lru_cache
 from pprint import pformat
 from time import sleep
 
@@ -144,6 +145,7 @@ def _toggl_request(url, method, data, headers, auth):
     return response
 
 
+@lru_cache(maxsize=Config.cache_size)
 def toggl(url, method, data=None, headers=None, config=None, address=None):
     """
     Makes an HTTP request to toggl.com. Returns the parsed JSON as dict.

--- a/toggl/utils/others.py
+++ b/toggl/utils/others.py
@@ -180,6 +180,6 @@ def toggl(url, method, data=None, headers=None, config=None, address=None):
     raise exception
 
 
-if Config.cache_requests:
+if Config.factory().cache_requests:
     # Manual conditional wrapping of the toggl function
-    toggl = lru_cache(maxsize=Config.cache_size)(toggl)
+    toggl = lru_cache(maxsize=Config.factory().cache_size)(toggl)


### PR DESCRIPTION
Adding a simple [LRU cache](https://docs.python.org/3/library/functools.html#functools.lru_cache) to the `api.others.toggl()` function that dispatches the API calls.
Can be disabled using configuration option `cache_requests`, and size can be set with `cache_size`.
Cache is cleared in all functions that dispatch a `PUT`, `POST` or `DELETE` API call.