### PR TITLE
Remove click typecheck from entry_continue

### DIFF
--- a/toggl/cli/commands.py
+++ b/toggl/cli/commands.py
@@ -367,7 +367,7 @@ def entry_stop(ctx, stop):
 
 
 @cli.command('continue', short_help='continue a time entry')
-@click.argument('descr', required=False, type=types.ResourceType(api.TimeEntry))
+@click.argument('descr', required=False)
 @click.option('--start', '-s', type=types.DateTimeType(), help='Sets a start time.')
 @click.pass_context
 def entry_continue(ctx, descr, start):


### PR DESCRIPTION
This allows `toggl continue Presentation` from the command line to work properly.

On my system, passing that in resulted in:
```
Error: Invalid value for "[DESCR]": Unknown Time entry under specification 'Presentation'!
```

While the `Presentation` entry is definitely found in existing entries (as checked via the `-d` flag). Without the click type check, it works nicely. I'm not sure if I broke any existing functionality with that change, but it hasn't crashed on me yet.

Back to the presentation! :smile: 