### PR TITLE
Allow Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
   - '3.5'
   - '3.6'
   - '3.7'
+  - '3.8'
 dist: xenial
 sudo: true
 install:

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ author = D. Robert Adams & Adam Uhlir
 author-email = hello@adam-uhlir.me
 license = MIT
 home-page = https://toggl.uhlir.dev
-python_requires = >=3.5.0, <3.8.0
+python_requires = >=3.5.0
 project_urls =
     Source = https://github.com/auhau/toggl-cli
     Documentation = https://toggl.uhlir.dev
@@ -18,6 +18,7 @@ classifier =
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
     Programming Language :: Python :: Implementation :: CPython
     Development Status :: 4 - Beta
     Topic :: Office/Business :: Scheduling


### PR DESCRIPTION
Arch Linux updated the system python version to 3.8, and I could not get this to run as it used to. After some digging I realized it was installing version 1.0!

I am using the current version from a local install on 3.8 right now, and, well, it has not exploded. I'll report back if I notice issues.