### PR TITLE
feat: sum and day command functions

### DIFF
--- a/toggl/cli/commands.py
+++ b/toggl/cli/commands.py
@@ -367,6 +367,7 @@ def entry_day(ctx, fields, use_reports, goal, timeoff, **conditions):
             time.sleep(timeoff*3600)
 
 def getTimePassed(entities):
+    """ sums the passed time from all the entities given """
     timePassed=0.
     running=False
     for entity in entities:
@@ -382,6 +383,9 @@ def getTimePassed(entities):
     return timePassed, running
 
 def notify(title, text):
+    """ this function will only work on OSX and needs to be extended for other OS
+    @title string for notification title
+    @text string for notification content """
     os.system("""
               osascript -e 'display notification "{}" with title "{}"'
               """.format(text, title))


### PR DESCRIPTION
`toggl sum` sums up the total amount of time.
`toggl day` sums up the time on the current day.
This should resolve #134.

Additionally this is capable to be used as a timer:
The functions have the ability to setup a “goal” amount of hours for a day - reflecting the hours that you want/have to work that day. For example 8 hours every weekday.
Then a notification is displayed when my work is done.  This currently only works on OSX though and needs further thought to support other OS.