### PR TITLE
Update Inquirer from 2.7.0 to 2.9.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pendulum==2.1.2
 requests>=2.23.0
 click==7.1.2
-inquirer==2.7.0
+inquirer==2.9.1
 PTable==0.9.2
 validate_email==1.3
 click-completion==0.5.2


### PR DESCRIPTION
There is a bug in blessed 1.17.6, it does not recognize python version to be above 3.2.2+
I am using python 3.9.9, and I know it fails with 3.10 too.

I ran the tests I could (And messed up my toggl account), I don't have premium, all failures seemed to be related to lacking premium, and the CLI works fine.