### PR TITLE
Replace unmaintained PTable with prettytable

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ pendulum==2.1.2
 requests>=2.23.0
 click==8.0.3
 inquirer==2.9.1
-prettytable==3.3.0
+prettytable==3.6.0
 validate_email==1.3
 click-completion==0.5.2
 pbr==5.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ pendulum==2.1.2
 requests>=2.23.0
 click==8.0.3
 inquirer==2.9.1
-PTable==0.9.2
+prettytable==3.3.0
 validate_email==1.3
 click-completion==0.5.2
 pbr==5.8.0


### PR DESCRIPTION
PTable was originally a fork of unmaintained PrettyTable.

But now PrettyTable is maintained (including by me) and PTable is unmaintained.

Let's switch back.

* https://pypi.org/project/PTable/
* https://pypi.org/project/prettytable/
