### PR TITLE
Fix default value of `estimated_hours`

### DIFF
--- a/toggl/api/models.py
+++ b/toggl/api/models.py
@@ -176,7 +176,7 @@ class Project(WorkspacedEntity):
     (Available only for Premium workspaces)
     """
 
-    estimated_hours = fields.IntegerField(default=0,premium=True)
+    estimated_hours = fields.IntegerField(default=0, premium=True)
     """
     If auto_estimates is true then the sum of task estimations is returned, otherwise user inserted hours.
 

--- a/toggl/api/models.py
+++ b/toggl/api/models.py
@@ -176,7 +176,7 @@ class Project(WorkspacedEntity):
     (Available only for Premium workspaces)
     """
 
-    estimated_hours = fields.IntegerField(premium=True)
+    estimated_hours = fields.IntegerField(default=0,premium=True)
     """
     If auto_estimates is true then the sum of task estimations is returned, otherwise user inserted hours.
 


### PR DESCRIPTION
Without integer as default value of `estimated_hours`, `null` is pushed to toggl and API response with 400 error code.
With `0` set as default value, a project is created by toggl API 

This is a fix for issue `toggl projects add -n "asd asd" --color 123` #275