### PR TITLE
feat: respect XDG spec for configuration files

### DIFF
--- a/toggl/cli/commands.py
+++ b/toggl/cli/commands.py
@@ -15,8 +15,6 @@ from toggl import api, exceptions, utils, __version__
 from toggl.cli import helpers, types
 from toggl.cli.themes import themes
 
-DEFAULT_CONFIG_PATH = '~/.togglrc'
-
 logger = logging.getLogger('toggl.cli.commands')
 click_completion.init()
 

--- a/toggl/utils/config.py
+++ b/toggl/utils/config.py
@@ -8,6 +8,7 @@ from collections import namedtuple
 import click
 import requests
 from pbr import version
+from pathlib import Path
 
 from toggl.utils import metas, bootstrap, migrations
 from toggl import exceptions
@@ -62,7 +63,7 @@ class IniConfigMixin:
         'version': IniEntry('version', str),
     }
 
-    DEFAULT_CONFIG_PATH = os.path.expanduser('~/.togglrc')
+    DEFAULT_CONFIG_PATH = Path.expanduser(Path('~/.togglrc'))
 
     def __init__(self, config_path=sentinel, **kwargs):  # type: (typing.Optional[str], **typing.Any) -> None
         self._config_path = self.DEFAULT_CONFIG_PATH if config_path == sentinel else config_path

--- a/toggl/utils/config.py
+++ b/toggl/utils/config.py
@@ -63,7 +63,10 @@ class IniConfigMixin:
         'version': IniEntry('version', str),
     }
 
-    DEFAULT_CONFIG_PATH = Path.expanduser(Path('~/.togglrc'))
+    if "XDG_CONFIG_HOME" in os.environ:
+        DEFAULT_CONFIG_PATH = Path(os.environ["XDG_CONFIG_HOME"]).joinpath(".togglrc")
+    else:
+        DEFAULT_CONFIG_PATH = Path.expanduser(Path('~/.togglrc'))
 
     def __init__(self, config_path=sentinel, **kwargs):  # type: (typing.Optional[str], **typing.Any) -> None
         self._config_path = self.DEFAULT_CONFIG_PATH if config_path == sentinel else config_path

--- a/toggl/utils/config.py
+++ b/toggl/utils/config.py
@@ -63,10 +63,18 @@ class IniConfigMixin:
         'version': IniEntry('version', str),
     }
 
+    _old_file_path = Path.expanduser(Path('~/.togglrc'))
+    
     if "XDG_CONFIG_HOME" in os.environ:
-        DEFAULT_CONFIG_PATH = Path(os.environ["XDG_CONFIG_HOME"]).joinpath(".togglrc")
+        _new_file_path = Path(os.environ["XDG_CONFIG_HOME"]).joinpath(".togglrc")
+        
+        if _new_file_path.exists() or not _old_file_path.exists():
+            DEFAULT_CONFIG_PATH = _new_file_path
+        else:
+            DEFAULT_CONFIG_PATH = _old_file_path
+            
     else:
-        DEFAULT_CONFIG_PATH = Path.expanduser(Path('~/.togglrc'))
+        DEFAULT_CONFIG_PATH = _old_file_path
 
     def __init__(self, config_path=sentinel, **kwargs):  # type: (typing.Optional[str], **typing.Any) -> None
         self._config_path = self.DEFAULT_CONFIG_PATH if config_path == sentinel else config_path


### PR DESCRIPTION
Use Path.expanduser from pathlib module instead of os module
Remove redundant DEFAULT_CONFIG_PATH in commands.py
Closes #126 