### PR TITLE
fix: projects and tasks

### DIFF
--- a/toggl/api/base.py
+++ b/toggl/api/base.py
@@ -222,7 +222,10 @@ class TogglSet(object):
         Helper method that fetches all objects from given URL and deserialize them.
         """
         fetched_entities = utils.toggl(url, 'get', config=config)
-
+        
+        if isinstance(fetched_entities, dict):
+            fetched_entities = fetched_entities.get('data')
+        
         if fetched_entities is None:
             return []
 

--- a/toggl/api/models.py
+++ b/toggl/api/models.py
@@ -195,7 +195,7 @@ class Project(WorkspacedEntity):
     (Available only for Premium workspaces)
     """
 
-    color = fields.IntegerField()
+    color = fields.StringField()
     """
     Id of the color selected for the project
     """


### PR DESCRIPTION
Fixes api.Project.objects.all() since color is now a string.

Fixes api.Task.objects.all() since that response data is still wrapped in an envelope.