### PR TITLE
chore: python 3.12 support

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,10 +3,10 @@ name: Tests
 on:
   push:
     branches:
-      - 'master'
+      - "master"
   pull_request:
     branches:
-      - '**'
+      - "**"
 
 jobs:
   python:
@@ -15,7 +15,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - name: Checkout
@@ -26,7 +26,7 @@ jobs:
       - name: Use Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
-          cache: 'pip'
+          cache: "pip"
           python-version: ${{ matrix.python-version }}
 
       - name: Install requirements

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 setuptools==69.0.3
-pendulum>=2.1.2
+pendulum==3.0.0
 requests>=2.23.0
 click==8.1.3
 inquirer==2.9.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-pendulum==2.1.2
+setuptools==69.0.3
+pendulum>=2.1.2
 requests>=2.23.0
 click==8.1.3
 inquirer==2.9.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ classifier =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Programming Language :: Python :: Implementation :: CPython
     Development Status :: 5 - Production/Stable
     Topic :: Office/Business :: Scheduling

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ author = D. Robert Adams & Adam Uhlir
 author_email = adam@uhlir.dev
 license = MIT
 home_page = https://toggl.uhlir.dev
-python_requires = >=3.7.0
+python_requires = >=3.8.0
 project_urls =
     Source = https://github.com/auhau/toggl-cli
     Documentation = https://toggl.uhlir.devg
@@ -15,7 +15,6 @@ classifier =
     License :: OSI Approved :: MIT License
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10

--- a/toggl/utils/migrations.py
+++ b/toggl/utils/migrations.py
@@ -97,7 +97,7 @@ class Migration200b1(MigrationBase):
     @staticmethod
     def migrate_timezone(parser):  # type: (configparser.ConfigParser) -> None
         tz = parser.get('options', 'timezone')
-        if tz not in pendulum.timezones:
+        if tz not in pendulum.timezones():
             click.echo('We have not recognized your timezone!')
             new_tz = inquirer.shortcuts.text(
                 'Please enter valid timezone. Default is your system\'s timezone.',


### PR DESCRIPTION
Closes #318

Unit tests were passing and local CLI installation was working, but integration test failed with 410(Gone) responses. I am assuming that's due to the v8 deprecation, but I think you already have a fix in the works for that.