### PR TITLE
fix: add requirements to run tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ validate_email==1.3
 click-completion==0.5.2
 pbr==5.8.0
 notify-py==0.3.42
-pytest-cov==5.0.0
+pytest-cov==2.12.1
 Faker==25.2.0
 factory-boy==3.3.0
 pytest-mock==3.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ notify-py==0.3.42
 pytest-cov==5.0.0
 Faker==25.2.0
 factory-boy==3.3.0
-pytest-mock==3.14.0
+pytest-mock==3.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,5 @@ pbr==5.8.0
 notify-py==0.3.42
 pytest-cov==2.12.1
 Faker==25.2.0
-factory-boy==3.3.0
+factory-boy==3.2.1
 pytest-mock==3.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,7 @@ validate_email==1.3
 click-completion==0.5.2
 pbr==5.8.0
 notify-py==0.3.42
+pytest-cov==5.0.0
+Faker==25.2.0
+factory-boy==3.3.0
+pytest-mock==3.14.0


### PR DESCRIPTION
Integration tests have not been running on contributors' machines due to missing dependencies from the `requirements.txt` file. This PR adds the four missing test dependencies.