### PR TITLE
Improve permissions of .togglrc file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,30 +2,31 @@
 
 Any contribution are welcomed.
 
-For submitting PRs, they need to have test coverage which pass the full run in Travis CI. 
+For submitting PRs, they need to have test coverage which pass the full run in Travis CI.
 
 ## Developing
 
 If you want to run the toggl CLI during development, I recommend you to use flow where you `pip install -e .`, which
-symlinks locally the package and then you can simply use the CLI like `toggl ls`.
+symlinks locally the package and then you can simply use the CLI like `toggl ls`. If you have the toggl CLI installed globally (e.g. via pipx) you'll also need to source your shell profile again to get the new symlinked version.
 
 Also, if you find yourself with non-descriptive exception, you can set env. variable `export TOGGL_EXCEPTIONS=1` which
-then will give you then the full stack trace. 
+ will then give you the full stack trace.
 
 ## Tests
 
-For running integration tests you need dummy account on Toggl, where **you don't have any important data** as the data 
+For running integration tests you need dummy account on Toggl, where **you don't have any important data** as the data
 will be messed up with and eventually **deleted**! Get API token for this test account and set it as an environmental variable
-`TOGGL_API_TOKEN`. Also figure out the Workspace ID of your account (`toggl workspace ls`) and set is as `TOGGL_WORKSPACE` 
+`TOGGL_API_TOKEN`. Also figure out the Workspace ID of your account (`toggl workspace ls`) and set is as `TOGGL_WORKSPACE`
 environmental variable.
 
 There are two sets of integration tests: normal and premium. To be able to run the premium set you have to have payed
 workspace. As this is quiet unlikely you can leave the testing on Travis CI as it runs also the premium tests set.
 
 Tests are written using `pytest` framework and are split into three categories (each having its own pytest mark):
- *  **unit** - unit tests testing mostly the framework around building the API wrappers
- *  **integration** - Integration tests which tests end to end coherence of API wrapper. Requires connectivity to Toggl API.
- *  **premium**: Subcategory of Integration tests that requires to have Premium/Paid workspace for the tests.
+
+* **unit** - unit tests testing mostly the framework around building the API wrappers
+* **integration** - Integration tests which tests end to end coherence of API wrapper. Requires connectivity to Toggl API.
+* **premium**: Subcategory of Integration tests that requires to have Premium/Paid workspace for the tests.
 
 ## Running tests
 

--- a/toggl/utils/config.py
+++ b/toggl/utils/config.py
@@ -2,7 +2,6 @@ import configparser
 import logging
 import os
 import platform
-import typing
 from collections import namedtuple
 
 import click
@@ -166,6 +165,8 @@ class IniConfigMixin:
 
         with open(self._config_path, 'w') as config_file:
             self._store.write(config_file)
+
+        os.chmod(self._config_path, 0o600)
 
 
 EnvEntry = namedtuple('EnvEntry', ['variable', 'type'])


### PR DESCRIPTION
## What
- add note about pip dev mode in contributing guide
- set permissions each time config file is persisted

## Why
- this file has creds or an API token so it should be restricted to reading by the owner only

## Refs

- closes: #336 